### PR TITLE
Limit return list to borrower and show overdue details

### DIFF
--- a/sheerent_app/lib/screens/return_screen.dart
+++ b/sheerent_app/lib/screens/return_screen.dart
@@ -33,7 +33,8 @@ class _ReturnScreenState extends State<ReturnScreen> {
       loading = true;
     });
 
-    final url = Uri.parse("$baseUrl/rentals?is_returned=false");
+    final url = Uri.parse(
+        "$baseUrl/rentals?is_returned=false&borrower_id=$loggedInUserId");
     try {
       final response = await http.get(url);
       if (response.statusCode == 200) {
@@ -336,9 +337,19 @@ class _ReturnScreenState extends State<ReturnScreen> {
                     final endTime = DateTime.parse(rental['end_time']);
                     final now = DateTime.now();
                     final remaining = endTime.difference(now);
-                    final remainingText = remaining.isNegative
-                        ? "⛔ 연체됨"
-                        : "⏰ ${remaining.inHours}시간 ${remaining.inMinutes.remainder(60)}분 남음";
+                    String remainingText;
+                    if (remaining.isNegative) {
+                      final overdue = now.difference(endTime);
+                      final itemPrice = item['price_per_day'] ?? 0;
+                      final overdueDays = (overdue.inHours / 24).ceil();
+                      final overdueFee = itemPrice * overdueDays;
+                      final penalty = (overdueFee * 0.1).round();
+                      remainingText =
+                          '⛔ ${overdue.inHours}시간 연체\n연체비용 ${formatter.format(overdueFee)}원 + 벌금 ${formatter.format(penalty)}원';
+                    } else {
+                      remainingText =
+                          '⏰ ${remaining.inHours}시간 ${remaining.inMinutes.remainder(60)}분 남음';
+                    }
 
                     final beforeImageUrl =
                         "$baseUrl/static/images/item_$itemId/before.jpg";

--- a/sheerent_server/app/routers/rentals.py
+++ b/sheerent_server/app/routers/rentals.py
@@ -132,10 +132,16 @@ def create_rental(rental: RentalCreate, db: Session = Depends(get_db)):
 
 # ✅ 2. 전체 대여 조회 + 필터링
 @router.get("/", response_model=List[RentalSchema])
-def get_rentals(is_returned: Optional[bool] = Query(None), db: Session = Depends(get_db)):
+def get_rentals(
+    is_returned: Optional[bool] = Query(None),
+    borrower_id: Optional[int] = Query(None),
+    db: Session = Depends(get_db),
+):
     query = db.query(Rental).options(joinedload(Rental.item))
     if is_returned is not None:
         query = query.filter(Rental.is_returned == is_returned)
+    if borrower_id is not None:
+        query = query.filter(Rental.borrower_id == borrower_id)
     return query.all()
 
 # ✅ 3. 반납 처리 + AI 분석 + 보증금 정산


### PR DESCRIPTION
## Summary
- filter `/rentals` by borrower via a new query parameter
- show only the logged-in user's rentals in *ReturnScreen*
- display overdue duration and fees when items are late

## Testing
- `python -m py_compile sheerent_server/app/routers/rentals.py`
- ⚠️ `flutter` and `dart` commands not available

------
https://chatgpt.com/codex/tasks/task_e_68490dca8ef8832da51b7720c851cc8a