### PR TITLE
Add insurance option to rental creation

### DIFF
--- a/sheerent_server/app/models/models.py
+++ b/sheerent_server/app/models/models.py
@@ -55,6 +55,7 @@ class Rental(Base):
     deposit_amount = Column(Integer, default=0)
     damage_reported = Column(Boolean, default=False)
     deducted_amount = Column(Integer, default=0)
+    has_insurance = Column(Boolean, default=False)
 
     item = relationship("Item", back_populates="rentals")
 

--- a/sheerent_server/app/routers/rentals.py
+++ b/sheerent_server/app/routers/rentals.py
@@ -99,7 +99,7 @@ def create_rental(rental: RentalCreate, db: Session = Depends(get_db)):
         price_per_hour = db_item.price_per_day  # per_hour일 경우
 
     rental_price = price_per_hour * hours
-    insurance_fee = round(rental_price * 0.05)  # 보험료 5%
+    insurance_fee = round(rental_price * 0.05) if rental.has_insurance else 0
     service_fee = round(rental_price * 0.05)    # 수수료 5%
     total_pay = rental_price + insurance_fee + service_fee
 
@@ -119,6 +119,7 @@ def create_rental(rental: RentalCreate, db: Session = Depends(get_db)):
         end_time=end_time,
         is_returned=False,
         deposit_amount=insurance_fee,
+        has_insurance=rental.has_insurance,
         damage_reported=False,
         deducted_amount=0
     )

--- a/sheerent_server/app/schemas/schemas.py
+++ b/sheerent_server/app/schemas/schemas.py
@@ -80,6 +80,7 @@ class RentalCreate(BaseModel):
     item_id: Optional[int] = None
     borrower_id: int
     end_time: datetime
+    has_insurance: bool = False
 
 # ✅ 대여 출력용 (응답용)
 class Rental(BaseModel):
@@ -93,6 +94,7 @@ class Rental(BaseModel):
     damage_reported: bool
     deposit_amount: int
     deducted_amount: int
+    has_insurance: bool
     item: Optional[ItemForRental]
 
     class Config:


### PR DESCRIPTION
## Summary
- add `has_insurance` flag to `RentalCreate` schema
- expose `has_insurance` in `Rental` output schema
- store `has_insurance` in the database model
- adjust `create_rental` logic to charge insurance only when selected

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848e9c4b544832d8823ccc9af742b3d