### PR TITLE
Add insurance flag to rentals

### DIFF
--- a/sheerent_server/alembic/versions/a1a1ce01624a_update_rental_table.py
+++ b/sheerent_server/alembic/versions/a1a1ce01624a_update_rental_table.py
@@ -1,0 +1,23 @@
+"""remove deposit_amount add has_insurance to rentals
+
+Revision ID: a1a1ce01624a
+Revises: b4e8d8b67a12
+Create Date: 2025-05-22 00:00:00
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 'a1a1ce01624a'
+down_revision: Union[str, None] = 'b4e8d8b67a12'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+def upgrade() -> None:
+    op.add_column('rentals', sa.Column('has_insurance', sa.Boolean(), nullable=True, server_default=sa.text('0')))
+    op.drop_column('rentals', 'deposit_amount')
+
+def downgrade() -> None:
+    op.add_column('rentals', sa.Column('deposit_amount', sa.Integer(), nullable=True, server_default='0'))
+    op.drop_column('rentals', 'has_insurance')

--- a/sheerent_server/app/models/models.py
+++ b/sheerent_server/app/models/models.py
@@ -52,8 +52,8 @@ class Rental(Base):
     start_time = Column(DateTime)
     end_time = Column(DateTime)
     is_returned = Column(Boolean, default=False)
-    deposit_amount = Column(Integer, default=0)
     damage_reported = Column(Boolean, default=False)
+    has_insurance = Column(Boolean, default=False)
     deducted_amount = Column(Integer, default=0)
 
     item = relationship("Item", back_populates="rentals")

--- a/sheerent_server/app/schemas/schemas.py
+++ b/sheerent_server/app/schemas/schemas.py
@@ -91,7 +91,7 @@ class Rental(BaseModel):
     end_time: datetime
     is_returned: bool
     damage_reported: bool
-    deposit_amount: int
+    has_insurance: bool
     deducted_amount: int
     item: Optional[ItemForRental]
 


### PR DESCRIPTION
## Summary
- add `has_insurance` flag to Rental model
- remove `deposit_amount` from Rental schema
- provide migration for database schema change

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848e9bceef4832d99f7327b99e632a6