### PR TITLE
Integrate Provider for user state

### DIFF
--- a/sheerent_app/lib/main.dart
+++ b/sheerent_app/lib/main.dart
@@ -1,9 +1,16 @@
 import 'package:flutter/material.dart';
 import 'screens/main_tab_view.dart';
 import 'screens/item_detail_page.dart'; // QR 코드 결과로 이동할 상세 페이지 import
+import 'package:provider/provider.dart';
+import 'providers/auth_provider.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(
+    ChangeNotifierProvider(
+      create: (_) => AuthProvider(),
+      child: const MyApp(),
+    ),
+  );
 }
 
 class MyApp extends StatelessWidget {

--- a/sheerent_app/lib/providers/auth_provider.dart
+++ b/sheerent_app/lib/providers/auth_provider.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/foundation.dart';
+
+class AuthProvider with ChangeNotifier {
+  int? userId;
+  String? userName;
+  bool? isAdmin;
+  int? point;
+
+  bool get isLoggedIn => userId != null;
+
+  void login({required int id, required String name, required bool admin, required int point}) {
+    userId = id;
+    userName = name;
+    isAdmin = admin;
+    this.point = point;
+    notifyListeners();
+  }
+
+  void logout() {
+    userId = null;
+    userName = null;
+    isAdmin = null;
+    point = null;
+    notifyListeners();
+  }
+
+  void updatePoint(int newPoint) {
+    point = newPoint;
+    notifyListeners();
+  }
+
+  void updateAdmin(bool admin) {
+    isAdmin = admin;
+    notifyListeners();
+  }
+}

--- a/sheerent_app/lib/screens/charge_point_screen.dart
+++ b/sheerent_app/lib/screens/charge_point_screen.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'dart:convert';
 import 'package:http/http.dart' as http;
 import '../globals.dart';
+import 'package:provider/provider.dart';
+import '../providers/auth_provider.dart';
 
 class ChargePointScreen extends StatefulWidget {
   const ChargePointScreen({super.key});
@@ -22,7 +24,8 @@ class _ChargePointScreenState extends State<ChargePointScreen> {
       return;
     }
 
-    final url = Uri.parse("$baseUrl/users/$loggedInUserId/charge");
+    final userId = context.read<AuthProvider>().userId;
+    final url = Uri.parse("$baseUrl/users/$userId/charge");
     try {
       final response = await http.put(
         url,

--- a/sheerent_app/lib/screens/item_detail_page.dart
+++ b/sheerent_app/lib/screens/item_detail_page.dart
@@ -2,6 +2,8 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import '../globals.dart';
+import 'package:provider/provider.dart';
+import '../providers/auth_provider.dart';
 
 class ItemDetailPage extends StatefulWidget {
   final int itemId;
@@ -29,7 +31,8 @@ class _ItemDetailPageState extends State<ItemDetailPage> {
   }
 
   Future<void> fetchUserPoint() async {
-  final url = Uri.parse('$baseUrl/users/$loggedInUserId');
+  final userId = context.read<AuthProvider>().userId;
+  final url = Uri.parse('$baseUrl/users/$userId');
   final response = await http.get(url);
 
   if (response.statusCode == 200) {
@@ -158,7 +161,7 @@ class _ItemDetailPageState extends State<ItemDetailPage> {
               ),
             ),
             const SizedBox(height: 24),
-            if (item!['owner_id'] == loggedInUserId)
+            if (item!['owner_id'] == context.read<AuthProvider>().userId)
               Center(
                 child: Text(
                   '❌ 자신이 등록한 물건은 대여할 수 없습니다.',
@@ -257,7 +260,7 @@ class _ItemDetailPageState extends State<ItemDetailPage> {
           ],
         ),
       ),
-      bottomNavigationBar: (item!['owner_id'] == loggedInUserId)
+      bottomNavigationBar: (item!['owner_id'] == context.read<AuthProvider>().userId)
           ? null
           : Padding(
               padding: const EdgeInsets.all(12.0),
@@ -292,7 +295,7 @@ class _ItemDetailPageState extends State<ItemDetailPage> {
                     headers: {"Content-Type": "application/json"},
                     body: jsonEncode({
                       "item_id": item!['id'],
-                      "borrower_id": loggedInUserId,
+                      "borrower_id": context.read<AuthProvider>().userId,
                       "end_time": endTime.toIso8601String(),
                       "total_pay": totalPay.round(),
                       "insurance": insuranceSelected,

--- a/sheerent_app/lib/screens/main_tab_view.dart
+++ b/sheerent_app/lib/screens/main_tab_view.dart
@@ -5,7 +5,6 @@ import 'return_screen.dart';
 import 'register_screen.dart';
 import 'rental_history_page.dart';
 import 'settings_screen.dart';
-import '../globals.dart';
 
 
 class MainTabView extends StatefulWidget {

--- a/sheerent_app/lib/screens/register_screen.dart
+++ b/sheerent_app/lib/screens/register_screen.dart
@@ -6,6 +6,8 @@ import 'package:image_picker/image_picker.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:path/path.dart' as path;
 import '../globals.dart';
+import 'package:provider/provider.dart';
+import '../providers/auth_provider.dart';
 
 class RegisterScreen extends StatefulWidget {
   final Map<String, dynamic>? itemToEdit;
@@ -193,7 +195,7 @@ Future<void> fetchLockers() async {
   }
 
 Future<bool> _submitItem() async {
-  if (!isLoggedIn()) {
+  if (!isLoggedIn(context)) {
     requireLogin(context);
     return false;
   }
@@ -201,7 +203,7 @@ Future<bool> _submitItem() async {
   final name = nameController.text.trim();
   final desc = descController.text.trim();
   final price = int.tryParse(priceController.text) ?? 0;
-  final ownerId = loggedInUserId!;
+  final ownerId = context.read<AuthProvider>().userId!;
   final locker = _selectedLocker;
 
   if (name.isEmpty ||

--- a/sheerent_app/lib/screens/rental_history_page.dart
+++ b/sheerent_app/lib/screens/rental_history_page.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'dart:convert';
 import 'package:http/http.dart' as http;
 import '../globals.dart';
+import 'package:provider/provider.dart';
+import '../providers/auth_provider.dart';
 import 'rental_detail_page.dart';
 
 class RentalHistoryPage extends StatefulWidget {
@@ -18,7 +20,7 @@ class _RentalHistoryPageState extends State<RentalHistoryPage> {
   @override
   void initState() {
     super.initState();
-    if (isLoggedIn()) {
+    if (isLoggedIn(context)) {
       fetchRentalHistory();
     }
   }
@@ -28,7 +30,8 @@ class _RentalHistoryPageState extends State<RentalHistoryPage> {
       loading = true;
     });
 
-    final url = Uri.parse("$baseUrl/users/$loggedInUserId/rentals");
+    final userId = context.read<AuthProvider>().userId;
+    final url = Uri.parse("$baseUrl/users/$userId/rentals");
     try {
       final response = await http.get(url);
       if (response.statusCode == 200) {
@@ -54,7 +57,7 @@ class _RentalHistoryPageState extends State<RentalHistoryPage> {
 
   @override
   Widget build(BuildContext context) {
-    if (!isLoggedIn()) {
+    if (!isLoggedIn(context)) {
       return Scaffold(
         appBar: AppBar(title: const Text("🧾 대여 이력")),
         body: const Center(child: Text("로그인이 필요한 기능입니다.")),

--- a/sheerent_app/lib/screens/return_screen.dart
+++ b/sheerent_app/lib/screens/return_screen.dart
@@ -6,6 +6,8 @@ import 'package:http/http.dart' as http;
 import 'package:path_provider/path_provider.dart';
 import 'package:path/path.dart' as path;
 import '../globals.dart';
+import 'package:provider/provider.dart';
+import '../providers/auth_provider.dart';
 
 
 class ReturnScreen extends StatefulWidget {
@@ -23,7 +25,7 @@ class _ReturnScreenState extends State<ReturnScreen> {
   @override
   void initState() {
     super.initState();
-    if (isLoggedIn()) {
+    if (isLoggedIn(context)) {
       fetchRentedItems();
     }
   }
@@ -33,8 +35,9 @@ class _ReturnScreenState extends State<ReturnScreen> {
       loading = true;
     });
 
+    final userId = context.read<AuthProvider>().userId;
     final url = Uri.parse(
-        "$baseUrl/rentals?is_returned=false&borrower_id=$loggedInUserId");
+        "$baseUrl/rentals?is_returned=false&borrower_id=$userId");
     try {
       final response = await http.get(url);
       if (response.statusCode == 200) {
@@ -226,7 +229,7 @@ class _ReturnScreenState extends State<ReturnScreen> {
     final uri = Uri.parse("$baseUrl/rentals/$rentalId/return");
     final request = http.MultipartRequest('PUT', uri);
 
-    request.fields['user_id'] = loggedInUserId.toString();
+    request.fields['user_id'] = context.read<AuthProvider>().userId.toString();
     request.fields['item_id'] = itemId.toString();
     request.files.add(await http.MultipartFile.fromPath('after_file', afterFile.path));
 
@@ -322,7 +325,7 @@ class _ReturnScreenState extends State<ReturnScreen> {
 
   @override
   Widget build(BuildContext context) {
-    if (!isLoggedIn()) {
+    if (!isLoggedIn(context)) {
       return Scaffold(
         appBar: AppBar(title: const Text("🔄 반납할 물품")),
         body: const Center(child: Text("로그인이 필요한 기능입니다.")),

--- a/sheerent_app/pubspec.yaml
+++ b/sheerent_app/pubspec.yaml
@@ -38,7 +38,8 @@ dependencies:
   http: ^0.13.6
   intl: ^0.17.0
   qr_flutter: ^4.0.0
-  qr_code_scanner: ^1.0.1 
+  qr_code_scanner: ^1.0.1
+  provider: ^6.0.5
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add Provider dependency
- create `AuthProvider` for login data
- wrap `MyApp` with `ChangeNotifierProvider`
- refactor global helpers to use Provider
- update screens to read auth state from Provider

## Testing
- `flutter pub get` *(fails: command not found)*
- `dart format lib` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68492df88fc4832dbcbf20c41d67833a