### PR TITLE
Update return flow for damaged items

### DIFF
--- a/sheerent_server/app/models/models.py
+++ b/sheerent_server/app/models/models.py
@@ -38,6 +38,7 @@ class Item(Base):
     images = Column(JSON)
     unit = Column(String(20))
     locker_number = Column(String(20), nullable=True)
+    damage_reported = Column(Boolean, default=False)
 
     owner = relationship("User", back_populates="items")
     rentals = relationship("Rental", back_populates="item")

--- a/sheerent_server/app/routers/items.py
+++ b/sheerent_server/app/routers/items.py
@@ -236,5 +236,6 @@ def repair_item(item_id: int, db: Session = Depends(get_db)):
         raise HTTPException(status_code=400, detail="현재 파손 상태가 아닙니다.")
 
     db_item.damage_reported = False
+    db_item.status = ItemStatus.registered
     db.commit()
     return {"message": "✅ 수리 처리가 완료되었습니다.", "item_id": item_id}

--- a/sheerent_server/app/routers/rentals.py
+++ b/sheerent_server/app/routers/rentals.py
@@ -7,7 +7,7 @@ import os
 import math
 
 from app.database import SessionLocal
-from app.models.models import Rental, Item, User, Message
+from app.models.models import Rental, Item, User, Message, ItemStatus
 from app.schemas.schemas import Rental as RentalSchema, RentalCreate
 from app.routers.ai import is_item_damaged
 
@@ -223,7 +223,8 @@ async def return_rental(
     rental.is_returned = True
     rental.damage_reported = damage_detected
     rental.deducted_amount = total_deduction
-    db_item.status = "registered"
+    db_item.damage_reported = damage_detected
+    db_item.status = ItemStatus.returned if damage_detected else ItemStatus.registered
     if damage_detected:
         insurance_text = "가입됨" if insurance_checked else "미가입"
         message = f"[파손 감지] '{db_item.name}'이(가) 반납 시 파손되었습니다.\n보험 가입 여부: {insurance_text}"

--- a/sheerent_server/app/schemas/schemas.py
+++ b/sheerent_server/app/schemas/schemas.py
@@ -50,6 +50,7 @@ class Item(BaseModel):
     images: Optional[List[str]] = []  # ✅ 쉼표로 이어진 문자열
     locker_number: Optional[str] = None
     description: Optional[str] = None
+    damage_reported: bool = False
 
     class Config:
         orm_mode = True


### PR DESCRIPTION
## Summary
- track whether an item is damaged directly on the item model
- mark returned items as unavailable if damage is detected
- allow repaired items to become rentable again

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bc90c4c30832d88f00192364b2520